### PR TITLE
Create policies.json

### DIFF
--- a/sources/assets/firefox/policies.json
+++ b/sources/assets/firefox/policies.json
@@ -1,0 +1,34 @@
+{
+  "policies": {
+    "DisableTelemetry": true,
+    "DisplayBookmarksToolbar": "always",
+    "ManagedBookmarks": [
+      {
+        "toplevel_name": "RedTeam"
+      },
+      {
+        "name": "Exegol",
+        "children": [
+          {
+            "url": "https://www.thehacker.recipes/",
+            "name": "THR"
+          },
+          {
+            "url": "https://tools.thehacker.recipes/",
+            "name": "TheHackerRecipes Tools"
+          }
+        ]
+      }
+    ],
+    "ExtensionSettings": {
+      "foxyproxy@eric.h.jung": {
+        "installation_mode": "force_installed",
+        "install_url": "https://addons.mozilla.org/firefox/downloads/file/4207660/foxyproxy_standard-8.6.xpi"
+      },
+      "wappalyzer@crunchlabz.com": {
+        "installation_mode": "force_installed",
+        "install_url": "https://addons.mozilla.org/firefox/downloads/file/4189626/wappalyzer-6.10.67.xpi"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

This aim to simplify the maintenance of the Firefox configuration using Firefox policy (https://mozilla.github.io/policy-templates/). Firefox policy can be very powerful to unify the Exegol Firefox configuration into one single file which contributors can easily contribute to.

For example, adding a single bookmark can be a tedious task since a contributor would need to download and open the SQLite database and this also means the bookmarks aren't visible easily.

If everything works fine, all we should need to do is place this `policies.json` file in the Firefox folder, I tested this on an Exegol container and it worked like a charm, this is also what I'm using in my NixOS config and it seems to work fine.

# Related issues

N / A

# Point of attention

Of course this is a simple example, if you like the idea, I can expand the policy file in order to add already presents bookmarks and extension.
